### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It has one tool, `chat` which relays a question to a configured AI Chat Provider
 
 ![Claude uses OpenAI](img/screencap.mov)
 
+<a href="https://glama.ai/mcp/servers/nuksdrfb55"><img width="380" height="200" src="https://glama.ai/mcp/servers/nuksdrfb55/badge" /></a>
+
 ## Development
 
 Install dependencies:


### PR DESCRIPTION
This PR adds a badge for the `any-chat-completions-mcp` server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/nuksdrfb55

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.